### PR TITLE
permit mention's of all users on comment

### DIFF
--- a/delibera_utils.php
+++ b/delibera_utils.php
@@ -276,3 +276,20 @@ function deliberaEncryptor($action, $string) {
 
 	return $output;
 }
+
+// função que modifica o array global $mcaAuthors do plugin mentions, dependencia do delibera
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+if(is_plugin_active('mention-comments-authors/mention-comments-authors.php'))
+{
+	add_action( 'comment_form' , 'delibera_mca_printnames', 11 );
+
+	function delibera_mca_printnames()
+	{
+                $users = get_users( array( 'fields' => array ( 'user_login' ) ) );
+                foreach( $users as $user )
+			$authors[] = array( 'val' => $user->user_login, 'meta' => $user->user_login);
+		 wp_localize_script( 'mca-comment-script', 'mcaAuthors', $authors );
+	}
+}
+
+


### PR DESCRIPTION
ref: https://github.com/ethymos/delibera/pull/62

Atualmente o plugin mentions, é dependencia do delibera, no entanto apenas usuários que participam de uma discussão que podem ser mencionados na discução. Acreditamos que a ideia seria poupar recursos com buscas grandes.

A solução busca apenas uma informação de cada usuário. Tentando manter o cuidado. No entanto como não temos a informação de quais usuário fazem parte de cada blog, vamos buscar todos os usuários na base.

Temos que fazer um teste de como fica isso com os 7k usuários que existem hoje no cnpc, seria o melhor teste.
